### PR TITLE
bug fix, add tqdm import

### DIFF
--- a/Utils/add_eye_kp.py
+++ b/Utils/add_eye_kp.py
@@ -4,6 +4,7 @@ import json
 import dlib
 from glob import glob 
 from multiprocessing import Pool, Process
+from tqdm import tqdm
 
 '''
 Add eye landmarks to the MIT Gaze Capture Dataset using DLib


### PR DESCRIPTION
This line: "for i in tqdm(files):" produces the following error: TypeError: 'module' object is not callable This is because tqdm module was not imported.